### PR TITLE
Update Elasticsearch CNAME to next-elasticsearch.nlb.ft.com

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ const health = async () => {
 	let ok, checkOutput;
 
 	try {
-		checkOutput = await(tcpFetch('next-elastic.glb.ft.com', 443));
+		checkOutput = await(tcpFetch('next-elasticsearch.nlb.ft.com', 443));
 		ok = true;
 	} catch(err) {
 		checkOutput = err.message;
@@ -76,8 +76,8 @@ const health = async () => {
 			id: 'elastic-search',
 			name: 'Check TCP/IP connectivity to this app\'s configured Elastic Search hostname on port 443',
 			businessImpact: 'fastFT posts will not be available in the Web App/iOS App/Android App',
-			technicalSummary: 'Attempts to connect to next-elastic.glb.ft.com:443. All content is requested from this host; without connectivity, fastFT content will not be available in the Apps',
-			panicGuide: `Check connectivity by running \`heroku run --app ${process.env.HEROKU_APP_NAME || '$HEROKU_APP_NAME'} nc -w 5 -z next-elastic.glb.ft.com 443\`.`,
+			technicalSummary: 'Attempts to connect to next-elasticsearch.nlb.ft.com:443. All content is requested from this host; without connectivity, fastFT content will not be available in the Apps',
+			panicGuide: `Check connectivity by running \`heroku run --app ${process.env.HEROKU_APP_NAME || '$HEROKU_APP_NAME'} nc -w 5 -z next-elasticsearch.nlb.ft.com 443\`.`,
 			ok,
 			checkOutput,
 		}]

--- a/test/controllers/search.js
+++ b/test/controllers/search.js
@@ -28,7 +28,7 @@ const makeSearchMock = host =>
 
 exports['search controller'] = {
 	async before() {
-		this.elasticSearchHost = await resolveCname('next-elastic.glb.ft.com');
+		this.elasticSearchHost = await resolveCname('next-elasticsearch.nlb.ft.com');
 	},
 
 	beforeEach() {


### PR DESCRIPTION
Follows on from #27, but the final address we've actually moved to AWS Route 53.